### PR TITLE
Updated to import TVMenuControl and useHeaderHeight correctly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import {
   StyleSheet,
   Text,
   TouchableOpacity,
-  TVMenuControl,
+  TVEventControl,
   View,
   LogBox,
 } from 'react-native';
@@ -207,7 +207,7 @@ const Reanimated2 = (setUseRea2: (useRea2: boolean) => void) => (
 function App(): React.ReactElement {
   const [useRea2, setUseRea2] = React.useState(true);
 
-  TVMenuControl.enableTVMenuKey();
+  TVEventControl.enableTVMenuKey();
   return (
     <NavigationContainer>
       {useRea2 ? Reanimated2(setUseRea2) : Reanimated1(setUseRea2)}

--- a/src/LightboxExample.tsx
+++ b/src/LightboxExample.tsx
@@ -27,7 +27,7 @@ import {
   TapGestureHandler,
   TapGestureHandlerGestureEvent,
 } from 'react-native-gesture-handler';
-import {useHeaderHeight} from '@react-navigation/stack';
+import {useHeaderHeight} from '@react-navigation/elements';
 
 const AnimatedImage = Animated.createAnimatedComponent(Image);
 


### PR DESCRIPTION
As of react-navigate v6 useHeaderHeight has moved to react-navigate/elements and TVMenuControl has changed name to TVEventControl